### PR TITLE
Fixed almasaeed2010/adminlte version to 2.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "gedmo/doctrine-extensions": "2.3.*",
     "jms/serializer-bundle": "0.12.0",
     "cocur/slugify": "^1.2",
-    "almasaeed2010/adminlte":"~2.0"
+    "almasaeed2010/adminlte":"2.3.2"
   },
   "autoload": {
     "psr-0": { "Tigreboite\\FunkylabBundle": "" }


### PR DESCRIPTION
I need to fix adminlte version in order to keep the same jQuery library version. It has been updated on 2.3.3.
